### PR TITLE
Added Travis Config & Grayson CLI Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+
+node_js:
+  - "node"
+
+cache:
+  directories:
+    - node_modules
+
+sudo: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -780,6 +780,12 @@
         }
       }
     },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
     "is-callable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
@@ -1210,6 +1216,15 @@
         "util-deprecate": "1.0.2"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.7.0"
+      }
+    },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
@@ -1224,6 +1239,15 @@
       "requires": {
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
+      }
+    },
+    "resolve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.0.tgz",
+      "integrity": "sha512-QdgZ5bjR1WAlpLaO5yHepFvC+o3rCr6wpfE2tpJNMkXdulf2jKomQBdNRQITF3ZKHNlT71syG98yQP03gasgnA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
       }
     },
     "resolve-from": {
@@ -1310,6 +1334,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
+      "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "ISC",
   "devDependencies": {
     "eslint": "^4.14.0",
+    "shelljs": "^0.8.1",
     "tap-spec": "^4.1.1",
     "tape": "^4.8.0"
   },

--- a/tests/grayson.test.js
+++ b/tests/grayson.test.js
@@ -1,0 +1,96 @@
+const test = require('tape');
+
+const fs = require('fs');
+const path = require('path');
+const shell = require('shelljs');
+
+test('Grayson Init', function(assert){
+	setup('init');
+
+	{
+		let message = 'creates `meta` directory';
+		let actual = fs.existsSync(`${__dirname}/test_dir/meta`);
+		let expected = true;
+
+		assert.equal(actual, expected, message);
+	}
+
+	{
+		let message = 'creates `markdown` directory';
+		let actual = fs.existsSync(`${__dirname}/test_dir/markdown`);
+		let expected = true;
+
+		assert.equal(actual, expected, message);
+	}
+
+	{
+		let message = 'creates `public` directory';
+		let actual = fs.existsSync(`${__dirname}/test_dir/public`);
+		let expected = true;
+
+		assert.equal(actual, expected, message);
+	}
+
+	{
+		let message = 'creates `package.json` file';
+		let actual = fs.existsSync(`${__dirname}/test_dir/package.json`);
+		let expected = true;
+		
+		assert.equal(actual, expected, message);
+	}
+
+	{
+		let message = 'creates `meta/defaults.json` file';
+		let actual = fs.existsSync(`${__dirname}/test_dir/meta/defaults.json`);
+		let expected = true;
+
+		assert.equal(actual, expected, message);
+	}
+	
+	teardown();
+	assert.end();
+});
+
+test('Grayson Gen', function(assert){
+	setup('init', function(){
+		for(let i = 1; i < 5; i++){
+			fs.writeFileSync(`${__dirname}/test_dir/markdown/${i}.md`, `# Hello ${i}`);
+		}
+
+		shell.exec(`node ${__dirname}/../bin/grayson-gen.js`);
+	});
+	
+	{
+		let message = 'creates `.html` files from `.md` files';
+		let actual = fs.existsSync(`${__dirname}/test_dir/public/index.html`);
+		let expected = true;
+
+		assert.equal(actual, expected, message);
+	}
+	
+	{
+		let message = 'creates `.html` file for *each* `.md` file';
+		let actual = Object.keys(fs.readdirSync(`${__dirname}/test_dir/public`)).length;
+		let expected = 5 + 3; // 5 generated files + 3 initialized directories
+
+		assert.equal(actual, expected, message);
+	}
+
+	teardown();
+	assert.end();
+});
+
+function setup(command, callback){
+	shell.exec(`mkdir -p ${__dirname}/test_dir`);
+	shell.cd(`${__dirname}/test_dir`);
+	shell.exec(`node ${__dirname}/../bin/grayson-${command}.js`);
+
+	if(callback){
+		callback();
+	}
+}
+
+function teardown(){
+	shell.cd(process.pwd);
+	shell.rm('-rf', path.join(__dirname, 'test_dir'));
+}

--- a/tests/nav-element.test.js
+++ b/tests/nav-element.test.js
@@ -1,7 +1,7 @@
 const test = require('tape');
 const navElement = require('../bin/lib/nav-element');
 
-test('navElement', function(assert){
+test('Nav Element', function(assert){
 	{
 		let message = 'outputs a string';
 		let actual = typeof navElement();


### PR DESCRIPTION
Added `shelljs` dependency to run tests on `grayson-init.js` and
`grayson-gen.js` scripts. This tests the actual functionality of the
grayson package, rather than testing just the inner functionality of the
templating.

Added config file for Travis CI, to provide feedback for users/consumers
as to the current state of the package's test coverage.
⚡️ Changes to be committed:
-	new file:   .travis.yml
-	modified:   package-lock.json
-	modified:   package.json
-	new file:   tests/grayson.test.js
-	modified:   tests/nav-element.test.js